### PR TITLE
Extendable idempotency

### DIFF
--- a/src/IdempotentAPI/Core/DefaultKeyGenerator.cs
+++ b/src/IdempotentAPI/Core/DefaultKeyGenerator.cs
@@ -1,0 +1,9 @@
+﻿namespace IdempotentAPI.Core;
+
+public class DefaultKeyGenerator : IKeyGenerator
+{
+    public string Generate(string prefix, string controller, string action, string idempotencyKey)
+    {
+        return $"{prefix}{idempotencyKey}";
+    }
+}

--- a/src/IdempotentAPI/Core/IIdempotencySettings.cs
+++ b/src/IdempotentAPI/Core/IIdempotencySettings.cs
@@ -14,4 +14,6 @@ public interface IIdempotencySettings
     public TimeSpan ExpiryTime { get; set; }
 
     public TimeSpan? DistributedLockTimeout { get; set; }
+    string RequestIdHeader { get; set; }
+    string OriginalRequestIdHeader { get; set; }
 }

--- a/src/IdempotentAPI/Core/IIdempotencySettings.cs
+++ b/src/IdempotentAPI/Core/IIdempotencySettings.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace IdempotentAPI.Core;
+
+public interface IIdempotencySettings
+{
+    public bool Enabled { get; set; }
+    public string HeaderKeyName { get; set; }
+
+    public string DistributedCacheKeysPrefix { get; set; }
+
+    public bool CacheOnlySuccessResponses { get; set; }
+
+    public TimeSpan ExpiryTime { get; set; }
+
+    public TimeSpan? DistributedLockTimeout { get; set; }
+}

--- a/src/IdempotentAPI/Core/IKeyGenerator.cs
+++ b/src/IdempotentAPI/Core/IKeyGenerator.cs
@@ -1,0 +1,6 @@
+﻿namespace IdempotentAPI.Core;
+
+public interface IKeyGenerator
+{
+    string Generate(string prefix, string controller, string action, string idempotencyKey);
+}

--- a/src/IdempotentAPI/Core/Idempotency.cs
+++ b/src/IdempotentAPI/Core/Idempotency.cs
@@ -159,7 +159,7 @@ namespace IdempotentAPI.Core
             {
                 LogDistributedLockNotAcquiredException("Before Controller", distributedLockNotAcquiredException);
 
-                context.Result = ResultOnDistributedLockNotAcquired(distributedLockNotAcquiredException);
+                context.Result = ResultOnDistributedLockNotAcquired(context, distributedLockNotAcquiredException);
                 return;
             }
 
@@ -174,7 +174,7 @@ namespace IdempotentAPI.Core
             if (cacheData.ContainsKey("Request.Inflight")
                 && uniqueRequesId.ToString().ToLower() != cacheData["Request.Inflight"].ToString().ToLower())
             {
-                context.Result = CreateResponse(HttpStatusCode.Conflict, null);
+                context.Result = CreateResponse(context, HttpStatusCode.Conflict, null);
                 return;
             }
 
@@ -189,7 +189,7 @@ namespace IdempotentAPI.Core
                 string currentRequestDataHash = GetRequestsDataHash(context.HttpContext.Request);
                 if (cachedRequestDataHash != currentRequestDataHash)
                 {
-                    context.Result = CreateResponse(HttpStatusCode.BadRequest, $"The Idempotency header key value '{_idempotencyKey}' was used in a different request.");
+                    context.Result = CreateResponse(context, HttpStatusCode.BadRequest, $"The Idempotency header key value '{_idempotencyKey}' was used in a different request.");
                     return;
                 }
 
@@ -304,12 +304,12 @@ namespace IdempotentAPI.Core
             return value.ToString();
         }
 
-        protected virtual IActionResult ResultOnDistributedLockNotAcquired(DistributedLockNotAcquiredException exception)
+        protected virtual IActionResult ResultOnDistributedLockNotAcquired(ActionExecutingContext context, DistributedLockNotAcquiredException exception)
         {
             return new ConflictResult();
         }
 
-        protected virtual IActionResult CreateResponse(HttpStatusCode status, object error) =>
+        protected virtual IActionResult CreateResponse(ActionExecutingContext context, HttpStatusCode status, object error) =>
             status switch
             {
                 HttpStatusCode.Conflict => new ConflictObjectResult(error),

--- a/src/IdempotentAPI/Core/Idempotency.cs
+++ b/src/IdempotentAPI/Core/Idempotency.cs
@@ -9,6 +9,7 @@ using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using IdempotentAPI.AccessCache;
 using IdempotentAPI.AccessCache.Exceptions;
+using IdempotentAPI.Core;
 using IdempotentAPI.Extensions;
 using IdempotentAPI.Helpers;
 using Microsoft.AspNetCore.Http;

--- a/src/IdempotentAPI/Core/IdempotencySettings.cs
+++ b/src/IdempotentAPI/Core/IdempotencySettings.cs
@@ -10,4 +10,6 @@ public class IdempotencySettings : IIdempotencySettings
     public bool CacheOnlySuccessResponses { get; set; } = true;
     public TimeSpan ExpiryTime { get; set; } = TimeSpan.FromHours(24);
     public TimeSpan? DistributedLockTimeout { get; set; }
+    public string RequestIdHeader { get; set; } = "X-Request-Id";
+    public string OriginalRequestIdHeader { get; set; } = "X-Original-Request-Id";
 }

--- a/src/IdempotentAPI/Core/IdempotencySettings.cs
+++ b/src/IdempotentAPI/Core/IdempotencySettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace IdempotentAPI.Core;
+
+public class IdempotencySettings : IIdempotencySettings
+{
+    public bool Enabled { get; set; } = true;
+    public string HeaderKeyName { get; set; } = "X-Idempotency-Key";
+    public string DistributedCacheKeysPrefix { get; set; } = "Api";
+    public bool CacheOnlySuccessResponses { get; set; } = true;
+    public TimeSpan ExpiryTime { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan? DistributedLockTimeout { get; set; }
+}

--- a/src/IdempotentAPI/Filters/IdempotencyAttribute.cs
+++ b/src/IdempotentAPI/Filters/IdempotencyAttribute.cs
@@ -41,6 +41,7 @@ namespace IdempotentAPI.Filters
             var distributedCache = serviceProvider.GetRequiredService<IIdempotencyAccessCache>();
             var logger = serviceProvider.GetService<ILogger<Idempotency>>() ?? NullLogger<Idempotency>.Instance;
             var settings = serviceProvider.GetService<IIdempotencySettings>();
+            var keyGenerator = serviceProvider.GetService<IKeyGenerator>() ?? new DefaultKeyGenerator();
 
             TimeSpan? distributedLockTimeout = DistributedLockTimeoutMilli.HasValue
                 ? DistributedLockTimeoutMilli >= 0
@@ -58,7 +59,7 @@ namespace IdempotentAPI.Filters
                 Enabled = Enabled.GetValueOrDefault(settings.Enabled)
             };
 
-            return new IdempotencyAttributeFilter(distributedCache, instanceSettings, logger);
+            return new IdempotencyAttributeFilter(distributedCache, instanceSettings, keyGenerator, logger);
         }
     }
 }

--- a/src/IdempotentAPI/Filters/IdempotencyAttributeFilter.cs
+++ b/src/IdempotentAPI/Filters/IdempotencyAttributeFilter.cs
@@ -1,42 +1,25 @@
-﻿using System;
-using IdempotentAPI.AccessCache;
+﻿using IdempotentAPI.AccessCache;
 using IdempotentAPI.Core;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IdempotentAPI.Filters
 {
     public class IdempotencyAttributeFilter : IActionFilter, IResultFilter
     {
-        private readonly bool _enabled;
-        private readonly TimeSpan _expiryTime;
-        private readonly string _headerKeyName;
-        private readonly string _distributedCacheKeysPrefix;
-        private readonly TimeSpan? _distributedLockTimeout;
-        private readonly bool _cacheOnlySuccessResponses;
         private readonly IIdempotencyAccessCache _distributedCache;
+        private readonly IIdempotencySettings _settings;
         private readonly ILogger<Idempotency> _logger;
 
         private Idempotency? _idempotency = null;
 
         public IdempotencyAttributeFilter(
             IIdempotencyAccessCache distributedCache,
-            ILogger<Idempotency> logger,
-            bool enabled,
-            TimeSpan expiryTime,
-            string headerKeyName,
-            string distributedCacheKeysPrefix,
-            TimeSpan? distributedLockTimeout,
-            bool cacheOnlySuccessResponses)
+            IIdempotencySettings settings,
+            ILogger<Idempotency> logger)
         {
             _distributedCache = distributedCache;
-            _enabled = enabled;
-            _expiryTime = expiryTime;
-            _headerKeyName = headerKeyName;
-            _distributedCacheKeysPrefix = distributedCacheKeysPrefix;
-            _distributedLockTimeout = distributedLockTimeout;
-            _cacheOnlySuccessResponses = cacheOnlySuccessResponses;
+            _settings = settings;
             _logger = logger;
         }
 
@@ -47,7 +30,7 @@ namespace IdempotentAPI.Filters
         public void OnActionExecuting(ActionExecutingContext context)
         {
             // If the Idempotency is disabled then stop
-            if (!_enabled)
+            if (!_settings.Enabled)
             {
                 return;
             }
@@ -55,14 +38,7 @@ namespace IdempotentAPI.Filters
             // Initialize only on its null (in case of multiple executions):
             if (_idempotency == null)
             {
-                _idempotency = new Idempotency(
-                    _distributedCache,
-                    _logger,
-                    _expiryTime,
-                    _headerKeyName,
-                    _distributedCacheKeysPrefix,
-                    _distributedLockTimeout,
-                    _cacheOnlySuccessResponses);
+                _idempotency = new Idempotency(_distributedCache, _settings, _logger);
             }
 
             _idempotency.ApplyPreIdempotency(context);
@@ -76,7 +52,7 @@ namespace IdempotentAPI.Filters
         {
             // If the Idempotency is disabled then stop.
             // Stop if the PreIdempotency step is not applied.
-            if (!_enabled || _idempotency == null)
+            if (!_settings.Enabled || _idempotency == null)
             {
                 return;
             }
@@ -100,7 +76,7 @@ namespace IdempotentAPI.Filters
         public void OnResultExecuted(ResultExecutedContext context)
         {
             // If the Idempotency is disabled then stop
-            if (!_enabled)
+            if (!_settings.Enabled)
             {
                 return;
             }

--- a/src/IdempotentAPI/Filters/IdempotencyAttributeFilter.cs
+++ b/src/IdempotentAPI/Filters/IdempotencyAttributeFilter.cs
@@ -9,6 +9,7 @@ namespace IdempotentAPI.Filters
     {
         private readonly IIdempotencyAccessCache _distributedCache;
         private readonly IIdempotencySettings _settings;
+        private readonly IKeyGenerator _keyGenerator;
         private readonly ILogger<Idempotency> _logger;
 
         private Idempotency? _idempotency = null;
@@ -16,10 +17,12 @@ namespace IdempotentAPI.Filters
         public IdempotencyAttributeFilter(
             IIdempotencyAccessCache distributedCache,
             IIdempotencySettings settings,
+            IKeyGenerator keyGenerator,
             ILogger<Idempotency> logger)
         {
             _distributedCache = distributedCache;
             _settings = settings;
+            _keyGenerator = keyGenerator;
             _logger = logger;
         }
 
@@ -38,7 +41,7 @@ namespace IdempotentAPI.Filters
             // Initialize only on its null (in case of multiple executions):
             if (_idempotency == null)
             {
-                _idempotency = new Idempotency(_distributedCache, _settings, _logger);
+                _idempotency = new Idempotency(_distributedCache, _settings, _keyGenerator, _logger);
             }
 
             _idempotency.ApplyPreIdempotency(context);

--- a/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
+++ b/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
@@ -1191,11 +1191,12 @@ namespace IdempotentAPI.UnitTests.FiltersTests
         {
             // Arrange
             string requestBodyString = @"{""message"":""This is a dummy message""}";
-            int expectedResponseHeadersCount = 2;
+            int expectedResponseHeadersCount = 3;
             var requestHeaders = new HeaderDictionary
             {
                 { "Content-Type", "application/json" },
-                { _headerKeyName, idempotencyKey }
+                { _headerKeyName, idempotencyKey },
+                { "X-Request-Id", "request-1234" },
             };
 
             TimeSpan? distributedLockTimeout = null;
@@ -1264,6 +1265,9 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             // Assert (response headers count)
             actionExecutingContext.HttpContext.Response.Headers.Count.Should().Be(expectedResponseHeadersCount);
+
+            // Assert headers
+            actionExecutingContext.HttpContext.Response.Headers["X-Request-Id"].Should().Equal("request-1234");
         }
 
         /// <summary>

--- a/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
+++ b/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
@@ -171,6 +171,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act
@@ -214,6 +215,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act
@@ -273,6 +275,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act
@@ -338,6 +341,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act
@@ -400,6 +404,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act
@@ -463,6 +468,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act
@@ -537,6 +543,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
 
@@ -642,6 +649,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
 
@@ -747,6 +755,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             var idempotencyRequest2 = new IdempotencyAttributeFilter(
@@ -760,6 +769,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act Part 1 (check cache):
@@ -870,6 +880,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             var idempotencyRequest2 = new IdempotencyAttributeFilter(
@@ -883,6 +894,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act Part 1 (check cache):
@@ -970,6 +982,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
 
@@ -1092,6 +1105,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             var idempotencyAttributeFilterRequest2 = new IdempotencyAttributeFilter(
@@ -1105,6 +1119,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act Part 1 (check cache):
@@ -1233,6 +1248,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
 
@@ -1326,6 +1342,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             var idempotencyAttributeFilterRequest2 = new IdempotencyAttributeFilter(
@@ -1339,6 +1356,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
             // Act with concurrent requests (check cache):
@@ -1427,6 +1445,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
 
@@ -1519,6 +1538,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                     HeaderKeyName = _headerKeyName,
                     ExpiryTime = TimeSpan.FromHours(1)
                 },
+                new DefaultKeyGenerator(),
                 _logger);
 
 

--- a/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
+++ b/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
@@ -162,13 +162,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 null,
-                _logger,
-                false,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = false,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act
             idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
@@ -202,13 +205,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 null,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act
             var ex = Assert.Throws<ArgumentNullException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
@@ -258,13 +264,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, distributedAccessLock);
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act
             var ex = Assert.Throws<ArgumentNullException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
@@ -320,13 +329,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act
             var ex = Assert.Throws<ArgumentNullException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
@@ -379,13 +391,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act
             var ex = Assert.Throws<ArgumentException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
@@ -439,13 +454,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act
             idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
@@ -510,13 +528,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
 
             // Act Part 1 (check cache):
@@ -612,13 +633,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
 
             // Act Part 1 (check cache):
@@ -714,23 +738,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             var idempotencyRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act Part 1 (check cache):
             idempotencyRequest1.OnActionExecuting(actionExecutingContext);
@@ -831,23 +861,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             var idempotencyRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act Part 1 (check cache):
             idempotencyRequest1.OnActionExecuting(actionExecutingContext);
@@ -925,13 +961,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
 
             // Act Part 1 (check cache):
@@ -1044,23 +1083,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilterRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             var idempotencyAttributeFilterRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act Part 1 (check cache):
             idempotencyAttributeFilterRequest1.OnActionExecuting(actionExecutingContext);
@@ -1179,13 +1224,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
 
             // Act
@@ -1269,23 +1317,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilterRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             var idempotencyAttributeFilterRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
             // Act with concurrent requests (check cache):
             var firstRequestTask = Task.Run(() => idempotencyAttributeFilterRequest1.OnActionExecuting(firstRequestExecutingContext));
@@ -1364,13 +1418,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
 
             // Act & Assert Part 1: Before the execution of the controller we store in-flight data (cache exists)
@@ -1453,13 +1510,16 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                _logger,
-                true,
-                TimeSpan.FromHours(1),
-                _headerKeyName,
-                _distributedCacheKeysPrefix,
-                distributedLockTimeout,
-                cacheOnlySuccessResponses);
+                new IdempotencySettings
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                    DistributedLockTimeout = distributedLockTimeout,
+                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                    HeaderKeyName = _headerKeyName,
+                    ExpiryTime = TimeSpan.FromHours(1)
+                },
+                _logger);
 
 
             // Act & Assert Part 1: Before the execution of the controller we store in-flight data (cache exists)

--- a/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
+++ b/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
@@ -1132,8 +1132,8 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             // should still be inflight and we should have a 409 Conflict result.
             idempotencyAttributeFilterRequest2.OnActionExecuting(inflightExecutingContext);
             Assert.NotNull(inflightExecutingContext.Result);
-            Assert.Equal(typeof(ConflictResult), inflightExecutingContext.Result.GetType());
-            Assert.Equal(409, ((ConflictResult)inflightExecutingContext.Result).StatusCode);
+            Assert.Equal(typeof(ConflictObjectResult), inflightExecutingContext.Result.GetType());
+            Assert.Equal(409, ((ConflictObjectResult)inflightExecutingContext.Result).StatusCode);
 
             // Act Part 3:
             idempotencyAttributeFilterRequest1.OnResultExecuted(resultExecutedContext);
@@ -1387,8 +1387,8 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             // result of the first request should still be inflight and we should have a 409
             // Conflict result.
             Assert.NotNull(conflictedActionResult);
-            Assert.Equal(typeof(ConflictResult), conflictedActionResult.GetType());
-            Assert.Equal(409, ((ConflictResult)conflictedActionResult).StatusCode);
+            Assert.Equal(typeof(ConflictObjectResult), conflictedActionResult.GetType());
+            Assert.Equal(409, ((ConflictObjectResult)conflictedActionResult).StatusCode);
         }
 
         /// <summary>


### PR DESCRIPTION
- Wraps the settings
- Allows the key generation to be replaced
- Allows for error responses to be overriden
- Includes the original request id in the response