### PR TITLE
inject a mapper for errors and to get the request id

### DIFF
--- a/src/IdempotentAPI/Core/DefaultRequestIdProvider.cs
+++ b/src/IdempotentAPI/Core/DefaultRequestIdProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace IdempotentAPI.Core;
+
+public class DefaultRequestIdProvider : IRequestIdProvider
+{
+    private readonly IIdempotencySettings _settings;
+
+    public DefaultRequestIdProvider(IIdempotencySettings settings)
+    {
+        _settings = settings;
+    }
+
+    public string Get(HttpRequest request)
+    {
+        request.Headers.TryGetValue(_settings.RequestIdHeader, out var value);
+        value = value.FirstOrDefault() ?? Guid.NewGuid().ToString();
+        return value.ToString();
+    }
+}

--- a/src/IdempotentAPI/Core/DefaultResponseMapper.cs
+++ b/src/IdempotentAPI/Core/DefaultResponseMapper.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+using IdempotentAPI.AccessCache.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace IdempotentAPI.Core;
+
+public class DefaultResponseMapper : IResponseMapper
+{
+    public IActionResult ResultOnDistributedLockNotAcquired(ActionExecutingContext context, DistributedLockNotAcquiredException exception)
+    {
+        return new ConflictResult();
+    }
+
+    public IActionResult CreateResponse(ActionExecutingContext context, HttpStatusCode status, object error) =>
+        status switch
+        {
+            HttpStatusCode.Conflict => new ConflictObjectResult(error),
+            HttpStatusCode.BadRequest => new BadRequestObjectResult(error),
+            _ => new StatusCodeResult((int)status)
+        };
+}

--- a/src/IdempotentAPI/Core/IRequestIdProvider.cs
+++ b/src/IdempotentAPI/Core/IRequestIdProvider.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace IdempotentAPI.Core;
+
+public interface IRequestIdProvider
+{
+    string Get(HttpRequest request);
+}

--- a/src/IdempotentAPI/Core/IResponseMapper.cs
+++ b/src/IdempotentAPI/Core/IResponseMapper.cs
@@ -1,0 +1,14 @@
+﻿using System.Net;
+using IdempotentAPI.AccessCache.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace IdempotentAPI.Core;
+
+public interface IResponseMapper
+{
+    public IActionResult ResultOnDistributedLockNotAcquired(ActionExecutingContext context,
+        DistributedLockNotAcquiredException exception);
+
+    public IActionResult CreateResponse(ActionExecutingContext context, HttpStatusCode status, object error);
+}

--- a/src/IdempotentAPI/Filters/IdempotencyAttribute.cs
+++ b/src/IdempotentAPI/Filters/IdempotencyAttribute.cs
@@ -38,6 +38,8 @@ namespace IdempotentAPI.Filters
             var logger = serviceProvider.GetService<ILogger<Idempotency>>() ?? NullLogger<Idempotency>.Instance;
             var settings = serviceProvider.GetService<IIdempotencySettings>();
             var keyGenerator = serviceProvider.GetService<IKeyGenerator>() ?? new DefaultKeyGenerator();
+            var requestIdProvider = serviceProvider.GetService<IRequestIdProvider>() ?? new DefaultRequestIdProvider(settings);
+            var responseMapper = serviceProvider.GetService<IResponseMapper>() ?? new DefaultResponseMapper();
 
             var distributedLockTimeout = DistributedLockTimeoutMilli >= 0
                 ? TimeSpan.FromMilliseconds(DistributedLockTimeoutMilli)
@@ -53,7 +55,7 @@ namespace IdempotentAPI.Filters
                 Enabled = Enabled || settings.Enabled
             };
 
-            return new IdempotencyAttributeFilter(distributedCache, instanceSettings, keyGenerator, logger);
+            return new IdempotencyAttributeFilter(distributedCache, instanceSettings, keyGenerator, requestIdProvider, responseMapper, logger);
         }
     }
 }

--- a/src/IdempotentAPI/Filters/IdempotencyAttributeFilter.cs
+++ b/src/IdempotentAPI/Filters/IdempotencyAttributeFilter.cs
@@ -10,6 +10,8 @@ namespace IdempotentAPI.Filters
         private readonly IIdempotencyAccessCache _distributedCache;
         private readonly IIdempotencySettings _settings;
         private readonly IKeyGenerator _keyGenerator;
+        private readonly IRequestIdProvider _requestIdProvider;
+        private readonly IResponseMapper _responseMapper;
         private readonly ILogger<Idempotency> _logger;
 
         private Idempotency? _idempotency = null;
@@ -18,11 +20,15 @@ namespace IdempotentAPI.Filters
             IIdempotencyAccessCache distributedCache,
             IIdempotencySettings settings,
             IKeyGenerator keyGenerator,
+            IRequestIdProvider requestIdProvider,
+            IResponseMapper responseMapper,
             ILogger<Idempotency> logger)
         {
             _distributedCache = distributedCache;
             _settings = settings;
             _keyGenerator = keyGenerator;
+            _requestIdProvider = requestIdProvider;
+            _responseMapper = responseMapper;
             _logger = logger;
         }
 
@@ -41,7 +47,7 @@ namespace IdempotentAPI.Filters
             // Initialize only on its null (in case of multiple executions):
             if (_idempotency == null)
             {
-                _idempotency = new Idempotency(_distributedCache, _settings, _keyGenerator, _logger);
+                _idempotency = new Idempotency(_distributedCache, _settings, _keyGenerator, _responseMapper, _requestIdProvider, _logger);
             }
 
             _idempotency.ApplyPreIdempotency(context);

--- a/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
+++ b/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
@@ -160,18 +160,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             TimeSpan? distributedLockTimeout = null;
             bool cacheOnlySuccessResponses = true;
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = false,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 null,
-                new IdempotencySettings
-                {
-                    Enabled = false,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act
@@ -204,18 +207,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             TimeSpan? distributedLockTimeout = null;
             bool cacheOnlySuccessResponses = true;
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 null,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act
@@ -264,18 +270,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             };
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, distributedAccessLock);
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act
@@ -330,18 +339,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act
@@ -393,18 +405,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             };
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act
@@ -457,18 +472,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
             bool cacheOnlySuccessResponses = true;
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act
@@ -532,18 +550,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
 
@@ -638,18 +659,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
 
@@ -744,32 +768,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             var idempotencyRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act Part 1 (check cache):
@@ -869,32 +890,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             var idempotencyRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act Part 1 (check cache):
@@ -971,18 +989,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 distributedCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
 
@@ -1094,32 +1115,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = _sharedDistributedCache.GetIdempotencyCache(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilterRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             var idempotencyAttributeFilterRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act Part 1 (check cache):
@@ -1238,18 +1256,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = _sharedDistributedCache.GetIdempotencyCache(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
 
@@ -1335,32 +1356,29 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilterRequest1 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             var idempotencyAttributeFilterRequest2 = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
             // Act with concurrent requests (check cache):
@@ -1438,18 +1456,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
 
@@ -1531,18 +1552,21 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             IIdempotencyAccessCache idempotencyCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
 
+            var settings = new IdempotencySettings
+            {
+                Enabled = true,
+                CacheOnlySuccessResponses = cacheOnlySuccessResponses,
+                DistributedLockTimeout = distributedLockTimeout,
+                DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
+                HeaderKeyName = _headerKeyName,
+                ExpiryTime = TimeSpan.FromHours(1)
+            };
             var idempotencyAttributeFilter = new IdempotencyAttributeFilter(
                 idempotencyCache,
-                new IdempotencySettings
-                {
-                    Enabled = true,
-                    CacheOnlySuccessResponses = cacheOnlySuccessResponses,
-                    DistributedLockTimeout = distributedLockTimeout,
-                    DistributedCacheKeysPrefix = _distributedCacheKeysPrefix,
-                    HeaderKeyName = _headerKeyName,
-                    ExpiryTime = TimeSpan.FromHours(1)
-                },
+                settings,
                 new DefaultKeyGenerator(),
+                new DefaultRequestIdProvider(settings),
+                new DefaultResponseMapper(),
                 _logger);
 
 


### PR DESCRIPTION
- IResponseMapper which allows for certain responses to be replaced
- IRequestIdProvider which allows for a different implementation to obtain a request id. Useful where the default differs