### PR TITLE
Return a bad request if header is missing

### DIFF
--- a/src/IdempotentAPI/Core/DefaultResponseMapper.cs
+++ b/src/IdempotentAPI/Core/DefaultResponseMapper.cs
@@ -19,4 +19,9 @@ public class DefaultResponseMapper : IResponseMapper
             HttpStatusCode.BadRequest => new BadRequestObjectResult(error),
             _ => new StatusCodeResult((int)status)
         };
+
+    public IActionResult ResultOnMissingIdempotencyKeyHeader(MissingIdempotencyKeyReason reason)
+    {
+        return new BadRequestResult();
+    }
 }

--- a/src/IdempotentAPI/Core/IResponseMapper.cs
+++ b/src/IdempotentAPI/Core/IResponseMapper.cs
@@ -11,4 +11,5 @@ public interface IResponseMapper
         DistributedLockNotAcquiredException exception);
 
     public IActionResult CreateResponse(ActionExecutingContext context, HttpStatusCode status, object error);
+    public IActionResult ResultOnMissingIdempotencyKeyHeader(MissingIdempotencyKeyReason reason);
 }

--- a/src/IdempotentAPI/Core/MissingIdempotencyKeyReason.cs
+++ b/src/IdempotentAPI/Core/MissingIdempotencyKeyReason.cs
@@ -1,0 +1,8 @@
+﻿namespace IdempotentAPI.Core;
+
+public enum MissingIdempotencyKeyReason
+{
+    HeaderNotPresentInRequest,
+    HeaderMissingValueInRequest,
+    MultipleHeadersInReques
+}

--- a/src/IdempotentAPI/Extensions/DependencyInjection/IdempotentAPIExtensions.cs
+++ b/src/IdempotentAPI/Extensions/DependencyInjection/IdempotentAPIExtensions.cs
@@ -1,4 +1,6 @@
-﻿using IdempotentAPI.AccessCache;
+﻿using System;
+using IdempotentAPI.AccessCache;
+using IdempotentAPI.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace IdempotentAPI.Extensions.DependencyInjection
@@ -13,6 +15,12 @@ namespace IdempotentAPI.Extensions.DependencyInjection
         public static IServiceCollection AddIdempotentAPI(this IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton<IIdempotencyAccessCache, IdempotencyAccessCache>();
+            serviceCollection.AddSingleton<IIdempotencySettings>(new IdempotencySettings()
+                {
+                    Enabled = true,
+                    CacheOnlySuccessResponses = true,
+                    ExpiryTime = TimeSpan.FromHours(2)
+                });
 
             return serviceCollection;
         }

--- a/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
+++ b/tests/IdempotentAPI.UnitTests/FiltersTests/IdempotencyAttribute_Tests.cs
@@ -296,7 +296,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
         [InlineData("PATCH", CacheImplementation.DistributedCache, DistributedAccessLockImplementation.None)]
         [InlineData("POST", CacheImplementation.FusionCache, DistributedAccessLockImplementation.None)]
         [InlineData("PATCH", CacheImplementation.FusionCache, DistributedAccessLockImplementation.None)]
-        public void ThrowsException_IfIdempotencyKeyHeaderNotExistsOnPostAndPatch(string httpMethod, CacheImplementation cacheImplementation, DistributedAccessLockImplementation distributedAccessLock)
+        public void BadRequest_IfIdempotencyKeyHeaderNotExistsOnPostAndPatch(string httpMethod, CacheImplementation cacheImplementation, DistributedAccessLockImplementation distributedAccessLock)
         {
             // Arrange
             var actionContext = ArrangeActionContextMock(httpMethod);
@@ -309,12 +309,6 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             TimeSpan? distributedLockTimeout = null;
             bool cacheOnlySuccessResponses = true;
-
-            // Expected error messages for different .NET Target Frameworks:
-            List<string> expectedExceptionMessages = new List<string>
-            {
-                "The Idempotency header key is not found. (Parameter 'IdempotencyKey')"
-            };
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, distributedAccessLock);
             var settings = new IdempotencySettings
@@ -335,10 +329,9 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                 _logger);
 
             // Act
-            var ex = Assert.Throws<ArgumentNullException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
+            idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
 
-            // Assert (Exception message)
-            Assert.Contains(ex.Message, expectedExceptionMessages);
+            Assert.IsType<BadRequestResult>(actionExecutingContext.Result);
         }
 
 
@@ -359,7 +352,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
         [InlineData("PATCH", CacheImplementation.DistributedCache, DistributedAccessLockImplementation.None)]
         [InlineData("POST", CacheImplementation.FusionCache, DistributedAccessLockImplementation.None)]
         [InlineData("PATCH", CacheImplementation.FusionCache, DistributedAccessLockImplementation.None)]
-        public void ThrowsException_IfIdempotencyKeyHeaderExistsWithoutValueOnPostAndPatch(string httpMethod, CacheImplementation cacheImplementation, DistributedAccessLockImplementation accessLockImplementation)
+        public void BadRequest_IfIdempotencyKeyHeaderExistsWithoutValueOnPostAndPatch(string httpMethod, CacheImplementation cacheImplementation, DistributedAccessLockImplementation accessLockImplementation)
         {
             // Arrange
             var requestHeaders = new HeaderDictionary
@@ -377,13 +370,6 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             TimeSpan? distributedLockTimeout = null;
             bool cacheOnlySuccessResponses = true;
-
-            // Expected error messages per .NET Target Framework:
-            List<string> expectedExceptionMessages = new List<string>
-            {
-                "An Idempotency header value is not found. (Parameter 'IdempotencyKey')"
-            };
-
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
             var settings = new IdempotencySettings
@@ -404,10 +390,9 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                 _logger);
 
             // Act
-            var ex = Assert.Throws<ArgumentNullException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
+            idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
 
-            // Assert (Exception message)
-            Assert.Contains(ex.Message, expectedExceptionMessages);
+            Assert.IsType<BadRequestResult>(actionExecutingContext.Result);
         }
 
         /// <summary>
@@ -427,7 +412,7 @@ namespace IdempotentAPI.UnitTests.FiltersTests
         [InlineData("PATCH", CacheImplementation.DistributedCache, DistributedAccessLockImplementation.None)]
         [InlineData("POST", CacheImplementation.FusionCache, DistributedAccessLockImplementation.None)]
         [InlineData("PATCH", CacheImplementation.FusionCache, DistributedAccessLockImplementation.None)]
-        public void ThrowsException_IfMultipleIdempotencyKeyHeaderExistsOnPostAndPatch(string httpMethod, CacheImplementation cacheImplementation, DistributedAccessLockImplementation accessLockImplementation)
+        public void BadRequest_IfMultipleIdempotencyKeyHeaderExistsOnPostAndPatch(string httpMethod, CacheImplementation cacheImplementation, DistributedAccessLockImplementation accessLockImplementation)
         {
             // Arrange
             var requestHeaders = new HeaderDictionary();
@@ -444,12 +429,6 @@ namespace IdempotentAPI.UnitTests.FiltersTests
 
             TimeSpan? distributedLockTimeout = null;
             bool cacheOnlySuccessResponses = true;
-
-            // Expected error messages per .NET Target Framework:
-            List<string> expectedExceptionMessages = new List<string>
-            {
-                "Multiple Idempotency keys were found. (Parameter 'IdempotencyKey')"
-            };
 
             IIdempotencyAccessCache distributedCache = MemoryDistributedCacheFixture.CreateCacheInstance(cacheImplementation, accessLockImplementation);
             var settings = new IdempotencySettings
@@ -470,10 +449,10 @@ namespace IdempotentAPI.UnitTests.FiltersTests
                 _logger);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext));
+            idempotencyAttributeFilter.OnActionExecuting(actionExecutingContext);
 
-            // Assert (Exception message)
-            Assert.Contains(ex.Message, expectedExceptionMessages);
+            // Assert
+            Assert.IsType<BadRequestResult>(actionExecutingContext.Result);
         }
 
 


### PR DESCRIPTION
`TryGetIdempotencyKey` was throwing if it couldn't get, which is inconsistent behaviour with  how `Try` methods are generally implemented. Also the use of this method suggested that a result should be returned rather than propogate an error up.